### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `imglab` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:imglab, "~> 0.1"}
+    {:imglab, "~> 0.2"}
   ]
 end
 ```
@@ -32,17 +32,17 @@ The easiest way to generate a URL is to specify the `source_name`, `path` and re
 
 ```elixir
 Imglab.url("assets", "image.jpeg", width: 500, height: 600)
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 
 Imglab.url("avatars", "user-01.jpeg", width: 300, height: 300, mode: :crop, crop: :face, format: :webp)
-"https://cdn.imglab.io/avatars/user-01.jpeg?width=300&height=300&mode=crop&crop=face&format=webp"
+"https://avatars.imglab-cdn.net/user-01.jpeg?width=300&height=300&mode=crop&crop=face&format=webp"
 ```
 
 If some specific settings are required for the source you can use a `Imglab.Source` struct instead of a `string` source name:
 
 ```elixir
 Imglab.url(Imglab.Source.new("assets"), "image.jpeg", width: 500, height: 600)
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 ```
 
 ### Using secure image sources
@@ -53,7 +53,7 @@ For sources that require signed URLs you can specify `secure_key` and `secure_sa
 "assets"
 |> Imglab.Source.new(secure_key: "assets-secure-key", secure_salt: "assets-secure-salt")
 |> Imglab.url("image.jpeg", width: 500, height: 600)
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&signature=generated-signature"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&signature=generated-signature"
 ```
 
 `signature` query parameter will be automatically generated and attached to the returned URL.
@@ -68,7 +68,7 @@ In the case that HTTP schema is required instead of HTTPS you can set `https` at
 "assets"
 |> Imglab.Source.new(https: false)
 |> Imglab.url("image.jpeg", width: 500, height: 600)
-"http://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+"http://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 ```
 
 > Note: HTTPS is the default and recommended way to generate URLs with imglab.
@@ -79,14 +79,14 @@ Any parameter from the imglab API can be used to generate URLs with `Imglab.url/
 
 ```elixir
 Imglab.url("assets", "image.jpeg", trim: "color", trim_color: "black")
-"https://cdn.imglab.io/assets/image.jpeg?trim=color&trim-color=black"
+"https://assets.imglab-cdn.net/image.jpeg?trim=color&trim-color=black"
 ```
 
 It is possible to use quoted atoms too:
 
 ```elixir
 Imglab.url("assets", "image.jpeg", trim: "color", "trim-color": "black")
-"https://cdn.imglab.io/assets/image.jpeg?trim=color&trim-color=black"
+"https://assets.imglab-cdn.net/image.jpeg?trim=color&trim-color=black"
 ```
 
 ### Specifying color parameters
@@ -96,19 +96,19 @@ Some imglab parameters can receive a color as value. It is possible to specify t
 ```elixir
 # Specifying a RGB color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "255,0,0")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
 
 # Specifying a RGBA color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "255,0,0,128")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
 
 # Specifying a named color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "red")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=red"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=red"
 
 # Specifying a hexadecimal color as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: :contain, background_color: "F00")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=F00"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=F00"
 ```
 
 You can additionally use `Imglab.Color` macros to specify these color values:
@@ -119,15 +119,15 @@ import Imglab.Color
 
 # Using color macro for a RGB color
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: "contain", background_color: color(255, 0, 0))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0"
 
 # Using color macro for a RGBA color
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: "contain", background_color: color(255, 0, 0, 128))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=255%2C0%2C0%2C128"
 
 # Using color macro for a named color
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, mode: "contain", background_color: color("red"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&mode=contain&background-color=red"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&mode=contain&background-color=red"
 ```
 
 > Note: specify hexadecimal color values using `Imglab.Color` macros is not allowed. You can use strings instead.
@@ -139,15 +139,15 @@ Some imglab parameters can receive a position as value. It is possible to specif
 ```elixir
 # Specifying a horizontal and vertical position as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: "left,top")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
 
 # Specifying a vertical and horizontal position as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: "top,left")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
 
 # Specifying a position as string
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: "left")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left"
 ```
 
 You can additionally use `Imglab.Position` macros to specify these position values:
@@ -158,15 +158,15 @@ import Imglab.Position
 
 # Using position macro for a horizontal and vertical position
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: position("left", "top"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left%2Ctop"
 
 # Using position macro for a vertical and horizontal position
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: position("top", "left"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=top%2Cleft"
 
 # Using position macro for a position
 Imglab.url("assets", "image.jpeg", width: 500, height: 500, mode: "crop", crop: position("left"))
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=500&mode=crop&crop=left"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=500&mode=crop&crop=left"
 ```
 
 ### Specifying URL parameters
@@ -175,14 +175,14 @@ Some imglab parameters can receive URLs as values. It is possible to specify the
 
 ```elixir
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, watermark: "logo.svg")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=logo.svg"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=logo.svg"
 ```
 
 And even use parameters if required:
 
 ```elixir
 Imglab.url("assets", "image.jpeg", width: 500, height: 600, watermark: "logo.svg?width=100&format=png")
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=logo.svg%3Fwidth%3D100%26format%3Dpng"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=logo.svg%3Fwidth%3D100%26format%3Dpng"
 ```
 
 Additionally you can use nested `Imglab.url/3` calls to specify these URL values:
@@ -195,7 +195,7 @@ Imglab.url(
   height: 600,
   watermark: Imglab.url("assets", "logo.svg", width: 100, format: "png")
 )
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
 ```
 
 If the resource is located in a different source we can specify it using `Imglab.url/3`:
@@ -208,7 +208,7 @@ Imglab.url(
   height: 600,
   watermark: Imglab.url("marketing", "logo.svg", width: 100, format: "png")
 )
-"https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fcdn.imglab.io%2Fmarketing%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
+"https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&watermark=https%3A%2F%2Fmarketing.imglab-cdn.net%2Flogo.svg%3Fwidth%3D100%26format%3Dpng"
 ```
 
 Using secure sources for URLs parameter values is possible too:
@@ -232,37 +232,37 @@ Imglab.url(
 For on-premises imglab server is possible to define custom sources pointing to your server location.
 
 * `:https` - a `boolean` value specifying if the source should use https or not (default: `true`)
-* `:host` - a `string` specifying the host where the imglab server is located. (default: `cdn.imglab.io`)
+* `:host` - a `string` specifying the host where the imglab server is located. (default: `imglab-cdn.net`)
 * `:port` - a `:inet.port_number` specifying a port where the imglab server is located.
-* `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path. (default: `false`)
+* `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path. (default: `true`)
 
-If we have our on-premises imglab server at `http://imglab.mycompany.com:8080` with a source named `web-images` we can use the following source settings to access a `logo.png` image:
+If we have our on-premises imglab server at `http://my-company.com:8080` with a source named `images` we can use the following source settings to access a `logo.png` image:
 
 ```elixir
-"web-images"
-|> Imglab.Source.new(https: false, host: "imglab.mycompany.com", port: 8080)
+"images"
+|> Imglab.Source.new(https: false, host: "my-company.com", port: 8080)
 |> Imglab.url("logo.png", width: 300, height: 300, format: "png")
-"http://imglab.mycompany.com:8080/web-images/logo.png?width=300&height=300&format=png"
+"http://images.my-company.com:8080/logo.png?width=300&height=300&format=png"
 ```
 
 It is possible to use secure sources too:
 
 ```elixir
-"web-images"
-|> Imglab.Source.new(https: false, host: "imglab.mycompany.com", port: 8080, secure_key: "web-images-secure-key", secure_salt: "web-images-secure-salt")
+"images"
+|> Imglab.Source.new(https: false, host: "my-company.com", port: 8080, secure_key: "images-secure-key", secure_salt: "images-secure-salt")
 |> Imglab.url("logo.png", width: 300, height: 300, format: "png")
-"http://imglab.mycompany.com:8080/web-images/logo.png?width=300&height=300&format=png&signature=generated-signature"
+"http://images.my-company.com:8080/logo.png?width=300&height=300&format=png&signature=generated-signature"
 ```
 
-### Using sudomains sources
+### Using sources with disabled subdomains
 
-In the case that your on-premises imglab server is configured to use source names as subdomains you can set `subdomains` attribute to `true` to generate URLs using subdomains:
+In the case that your on-premises imglab server is configured to use source names as paths instead of subdomains you can set `subdomains` attribute to `false`:
 
 ```elixir
-"web-images"
-|> Imglab.Source.new(https: false, host: "imglab.mycompany.com", port: 8080, subdomains: true)
-|> Imglab.url("marketing/logo.png", width: 300, height: 300, format: "png")
-"http://web-images.imglab.mycompany.com:8080/marketing/logo.png?width=300&height=300&format=png"
+"images"
+|> Imglab.Source.new(https: false, host: "my-company.com", port: 8080, subdomains: false)
+|> Imglab.url("logo.png", width: 300, height: 300, format: "png")
+"http://my-company.com:8080/images/logo.png?width=300&height=300&format=png"
 ```
 
 ## License

--- a/lib/imglab.ex
+++ b/lib/imglab.ex
@@ -19,14 +19,14 @@ defmodule Imglab do
   The first parameter can be a `string` with the name of the source in the case that no additional settings for the source are needed:
 
       iex> Imglab.url("assets", "image.jpeg", width: 500, height: 600)
-      "https://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+      "https://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 
   Or a [Source struct](`t:Imglab.Source.t/0`) created with `Imglab.Source.new/2` specifying additional settings for the source if needed:
 
       iex> "assets"
       iex> |> Imglab.Source.new()
       iex> |> Imglab.url("image.jpeg", width: 500, height: 600)
-      "https://cdn.imglab.io/assets/image.jpeg?width=500&height=600"
+      "https://assets.imglab-cdn.net/image.jpeg?width=500&height=600"
 
   ### Secured sources
 
@@ -35,7 +35,7 @@ defmodule Imglab do
       iex> "assets"
       iex> |> Imglab.Source.new(secure_key: "qxxKNvxRONOMklcGJBVczefrJnE=", secure_salt: "e9bXw6/HIMGTWcmAYArHA5jpIAE=")
       iex> |> Imglab.url("image.jpeg", width: 500, height: 600)
-      "https://cdn.imglab.io/assets/image.jpeg?width=500&height=600&signature=MX0DlvzVo39-_Dh_YqPbOnrayWVabIWaSDzi-9PfGHQ"
+      "https://assets.imglab-cdn.net/image.jpeg?width=500&height=600&signature=MX0DlvzVo39-_Dh_YqPbOnrayWVabIWaSDzi-9PfGHQ"
 
   The `signature` query string will be automatically added to the URL.
 
@@ -46,7 +46,7 @@ defmodule Imglab do
   The second parameter must be a `string` defining the path to the resource.
 
       iex> Imglab.url("assets", "path/to/myimage.jpeg", width: 500, height: 600)
-      "https://cdn.imglab.io/assets/path/to/myimage.jpeg?width=500&height=600"
+      "https://assets.imglab-cdn.net/path/to/myimage.jpeg?width=500&height=600"
 
   ## Params
 
@@ -55,17 +55,17 @@ defmodule Imglab do
   Some imglab parameters use hyphens inside their names. You can use atoms with underscores, these will be normalized to the correct format used by imglab API.
 
       iex> Imglab.url("assets", "image.jpeg", width: 500, trim: "color", trim_color: "orange")
-      "https://cdn.imglab.io/assets/image.jpeg?width=500&trim=color&trim-color=orange"
+      "https://assets.imglab-cdn.net/image.jpeg?width=500&trim=color&trim-color=orange"
 
   Or you can define a quoted atom instead:
 
       iex> Imglab.url("assets", "image.jpeg", width: 500, trim: "color", "trim-color": "orange")
-      "https://cdn.imglab.io/assets/image.jpeg?width=500&trim=color&trim-color=orange"
+      "https://assets.imglab-cdn.net/image.jpeg?width=500&trim=color&trim-color=orange"
 
   If no params are specified a URL without query params will be generated:
 
       iex> Imglab.url("assets", "image.jpeg")
-      "https://cdn.imglab.io/assets/image.jpeg"
+      "https://assets.imglab-cdn.net/image.jpeg"
 
   """
   @spec url(binary | Source.t(), binary, keyword) :: binary
@@ -108,7 +108,7 @@ defmodule Imglab do
   @spec encode_params(Source.t(), binary, list) :: binary
   defp encode_params(%Source{} = source, path, params)
        when is_binary(path) and is_list(params) and length(params) > 0 do
-    if Source.secure?(source) do
+    if Source.is_secure?(source) do
       signature = Signature.generate(source, path, URI.encode_query(params))
 
       URI.encode_query(params ++ [{"signature", signature}])
@@ -118,7 +118,7 @@ defmodule Imglab do
   end
 
   defp encode_params(%Source{} = source, path, _params) when is_binary(path) do
-    if Source.secure?(source) do
+    if Source.is_secure?(source) do
       signature = Signature.generate(source, path)
 
       URI.encode_query(signature: signature)

--- a/lib/imglab/source.ex
+++ b/lib/imglab/source.ex
@@ -3,9 +3,9 @@ defmodule Imglab.Source do
   Provides a way to define and store information about a imglab source.
   """
 
-  @default_host "cdn.imglab.io"
+  @default_host "imglab-cdn.net"
   @default_https true
-  @default_subdomains false
+  @default_subdomains true
 
   @derive {Inspect, except: [:secure_key, :secure_salt]}
   @enforce_keys [:name]
@@ -37,12 +37,12 @@ defmodule Imglab.Source do
 
   The accepted options are:
 
-    * `:host` - a `string` specifying the host where the imglab server is located, only for imglab on-premises (default: `"cdn.imglab.io"`)
+    * `:host` - a `string` specifying the host where the imglab server is located, only for imglab on-premises (default: `"imglab-cdn.net"`)
     * `:https` - a `boolean` value specifying if the source should use https or not (default: `true`)
     * `:port` - a `:inet.port_number` specifying a port where the imglab server is located, only for imglab on-premises
     * `:secure_key` - a `string` specifying the source secure key
     * `:secure_salt` - a `string` specifying the source secure salt
-    * `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path, only for imglab on-premises (default: `false`)
+    * `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path, only for imglab on-premises (default: `true`)
 
   > Note: `secure_key` and `secure_salt` paramaters are secrets that should not be added to the code. Please use environment vars or other secure method to use them in your project.
 
@@ -50,24 +50,24 @@ defmodule Imglab.Source do
 
       iex> Imglab.Source.new("assets")
       %Imglab.Source{
-        host: "cdn.imglab.io",
-        https: true,
-        name: "assets",
-        port: nil,
-        secure_key: nil,
-        secure_salt: nil,
-        subdomains: false
-      }
-
-      iex> Imglab.Source.new("assets", subdomains: true)
-      %Imglab.Source{
-        host: "cdn.imglab.io",
+        host: "imglab-cdn.net",
         https: true,
         name: "assets",
         port: nil,
         secure_key: nil,
         secure_salt: nil,
         subdomains: true
+      }
+
+      iex> Imglab.Source.new("assets", subdomains: false)
+      %Imglab.Source{
+        host: "imglab-cdn.net",
+        https: true,
+        name: "assets",
+        port: nil,
+        secure_key: nil,
+        secure_salt: nil,
+        subdomains: false
       }
 
       iex> Imglab.Source.new("assets", https: false, host: "imglab.net", port: 8080)
@@ -78,18 +78,18 @@ defmodule Imglab.Source do
         port: 8080,
         secure_key: nil,
         secure_salt: nil,
-        subdomains: false
+        subdomains: true
       }
 
       iex> Imglab.Source.new("assets", secure_key: "secure-key", secure_salt: "secure-salt")
       %Imglab.Source{
-        host: "cdn.imglab.io",
+        host: "imglab-cdn.net",
         https: true,
         name: "assets",
         port: nil,
         secure_key: "secure-key",
         secure_salt: "secure-salt",
-        subdomains: false
+        subdomains: true
       }
 
   """
@@ -129,8 +129,8 @@ defmodule Imglab.Source do
   def path(%__MODULE__{} = source, path) when is_binary(path), do: Path.join(source.name, path)
 
   @doc false
-  @spec secure?(t) :: boolean
-  def secure?(%__MODULE__{} = source) do
+  @spec is_secure?(t) :: boolean
+  def is_secure?(%__MODULE__{} = source) do
     !is_nil(source.secure_key) && !is_nil(source.secure_salt)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Imglab.MixProject do
   def project do
     [
       app: :imglab,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/imglab/source_test.exs
+++ b/test/imglab/source_test.exs
@@ -7,21 +7,20 @@ defmodule Imglab.SourceTest do
   test "new/2" do
     assert Source.new("assets") == %Source{
              name: "assets",
-             subdomains: false,
+             subdomains: true,
              https: true,
-             host: "cdn.imglab.io",
+             host: "imglab-cdn.net",
              port: nil,
              secure_key: nil,
              secure_salt: nil
            }
-
 
     assert Source.new("assets", host: "imglab.net") == %Source{name: "assets", host: "imglab.net"}
     assert Source.new("assets", https: false) == %Source{name: "assets", https: false}
     assert Source.new("assets", port: 8080) == %Source{name: "assets", port: 8080}
     assert Source.new("assets", secure_key: "secure-key") == %Source{name: "assets", secure_key: "secure-key"}
     assert Source.new("assets", secure_salt: "secure-salt") == %Source{name: "assets", secure_salt: "secure-salt"}
-    assert Source.new("assets", subdomains: true) == %Source{name: "assets", subdomains: true}
+    assert Source.new("assets", subdomains: false) == %Source{name: "assets", subdomains: false}
   end
 
   test "scheme/1" do
@@ -31,16 +30,16 @@ defmodule Imglab.SourceTest do
   end
 
   test "host/1" do
-    assert Source.host(Source.new("assets")) == "cdn.imglab.io"
-    assert Source.host(Source.new("assets", subdomains: false)) == "cdn.imglab.io"
+    assert Source.host(Source.new("assets")) == "assets.imglab-cdn.net"
+    assert Source.host(Source.new("assets", subdomains: false)) == "imglab-cdn.net"
     assert Source.host(Source.new("assets", subdomains: false, host: "imglab.net")) == "imglab.net"
-    assert Source.host(Source.new("assets", subdomains: true)) == "assets.cdn.imglab.io"
+    assert Source.host(Source.new("assets", subdomains: true)) == "assets.imglab-cdn.net"
     assert Source.host(Source.new("assets", subdomains: true, host: "imglab.net")) == "assets.imglab.net"
   end
 
   test "path/2" do
-    assert Source.path(Source.new("assets"), "example.jpeg") == "assets/example.jpeg"
-    assert Source.path(Source.new("assets"), "subfolder/example.jpeg") == "assets/subfolder/example.jpeg"
+    assert Source.path(Source.new("assets"), "example.jpeg") == "example.jpeg"
+    assert Source.path(Source.new("assets"), "subfolder/example.jpeg") == "subfolder/example.jpeg"
     assert Source.path(Source.new("assets", subdomains: false), "example.jpeg") == "assets/example.jpeg"
 
     assert Source.path(Source.new("assets", subdomains: false), "subfolder/example.jpeg") ==
@@ -50,9 +49,10 @@ defmodule Imglab.SourceTest do
     assert Source.path(Source.new("assets", subdomains: true), "subfolder/example.jpeg") == "subfolder/example.jpeg"
   end
 
-  test "secure?/1" do
-    assert Source.secure?(Source.new("assets")) == false
-    assert Source.secure?(Source.new("assets", secure_key: "secure-key")) == false
-    assert Source.secure?(Source.new("assets", secure_key: "secure-key", secure_salt: "secure-salt")) == true
+  test "is_secure?/1" do
+    assert Source.is_secure?(Source.new("assets")) == false
+    assert Source.is_secure?(Source.new("assets", secure_key: "secure-key")) == false
+    assert Source.is_secure?(Source.new("assets", secure_salt: "secure-salt")) == false
+    assert Source.is_secure?(Source.new("assets", secure_key: "secure-key", secure_salt: "secure-salt")) == true
   end
 end

--- a/test/imglab_test.exs
+++ b/test/imglab_test.exs
@@ -14,19 +14,19 @@ defmodule ImglabTest do
     test "without params" do
       url = Imglab.url("assets", "example.jpeg")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg"
     end
 
     test "with params" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with params using string path" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, watermark: "example.svg", format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
     end
 
     test "with params using string path with inline params" do
@@ -40,45 +40,45 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     test "with params using rgb color macro" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, background_color: color(255, 128, 122))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&background-color=255%2C128%2C122"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&background-color=255%2C128%2C122"
     end
 
     test "with params using rgba color macro" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, background_color: color(255, 128, 122, 128))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&background-color=255%2C128%2C122%2C128"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&background-color=255%2C128%2C122%2C128"
     end
 
     test "with params using named color macro" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, background_color: color("blue"))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&background-color=blue"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&background-color=blue"
     end
 
     test "with params using horizontal and vertical position macro" do
       url =
         Imglab.url("assets", "example.jpeg", width: 200, height: 300, mode: "crop", crop: position("left", "bottom"))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&mode=crop&crop=left%2Cbottom"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&mode=crop&crop=left%2Cbottom"
     end
 
     test "with params using vertical and horizontal position macro" do
       url =
         Imglab.url("assets", "example.jpeg", width: 200, height: 300, mode: "crop", crop: position("bottom", "left"))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&mode=crop&crop=bottom%2Cleft"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&mode=crop&crop=bottom%2Cleft"
     end
 
     test "with params using position macro" do
       url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, mode: "crop", crop: position("left"))
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&mode=crop&crop=left"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&mode=crop&crop=left"
     end
 
     test "with params using url/3 function with source" do
@@ -94,7 +94,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     test "with params using url/3 function with source name" do
@@ -108,91 +108,91 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     test "with params using atoms with underscores" do
       url = Imglab.url("assets", "example.jpeg", trim: "color", trim_color: "orange")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
     test "with params using atoms with hyphens" do
       url = Imglab.url("assets", "example.jpeg", trim: "color", "trim-color": "orange")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
     test "with path starting with slash" do
       url = Imglab.url("assets", "/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting with slash using reserved characters" do
       url = Imglab.url("assets", "/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting and ending with slash" do
       url = Imglab.url("assets", "/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting and ending with slash using reserved characters" do
       url = Imglab.url("assets", "/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting with slash" do
       url = Imglab.url("assets", "/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting with slash using reserved characters" do
       url = Imglab.url("assets", "/subfolder images/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting and ending with slash" do
       url = Imglab.url("assets", "/subfolder/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting and ending with slash using reserved characters" do
       url = Imglab.url("assets", "/subfolder images/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a http url" do
       url = Imglab.url("assets", "http://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a http url with reserved characters" do
       url = Imglab.url("assets", "http://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a https url" do
       url = Imglab.url("assets", "https://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a https url with reserved characters" do
       url = Imglab.url("assets", "https://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
   end
 
@@ -203,7 +203,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("example.jpeg")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg"
     end
 
     test "with params" do
@@ -212,7 +212,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with params using string path" do
@@ -221,7 +221,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("example.jpeg", width: 200, height: 300, watermark: "example.svg", format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg&format=png"
     end
 
     test "with params using string path with inline params" do
@@ -235,7 +235,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     test "with params using url/3 with source" do
@@ -251,7 +251,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     test "with params using url/3 function with source name" do
@@ -267,7 +267,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png"
     end
 
     test "with params using atoms with underscores" do
@@ -276,7 +276,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("example.jpeg", trim: "color", trim_color: "orange")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
     test "with params using atoms with hyphens" do
@@ -285,25 +285,25 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("example.jpeg", trim: "color", "trim-color": "orange")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
-    test "with subdomains" do
+    test "with disabled subdomains" do
       url =
         "assets"
-        |> Source.new(subdomains: true)
+        |> Source.new(subdomains: false)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://assets.cdn.imglab.io/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://imglab-cdn.net/assets/example.jpeg?width=200&height=300&format=png"
     end
 
-    test "with http" do
+    test "with disabled https" do
       url =
         "assets"
         |> Source.new(https: false)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "http://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "http://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with host" do
@@ -312,7 +312,7 @@ defmodule ImglabTest do
         |> Source.new(host: "imglab.net")
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://imglab.net/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with port" do
@@ -321,16 +321,16 @@ defmodule ImglabTest do
         |> Source.new(port: 8080)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io:8080/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net:8080/example.jpeg?width=200&height=300&format=png"
     end
 
-    test "with subdomains, http, host and port" do
+    test "with disabled subdomains, disabled https, host and port" do
       url =
         "assets"
-        |> Source.new(subdomains: true, https: false, host: "imglab.net", port: 8080)
+        |> Source.new(subdomains: false, https: false, host: "imglab.net", port: 8080)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "http://assets.imglab.net:8080/example.jpeg?width=200&height=300&format=png"
+      assert url == "http://imglab.net:8080/assets/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting with slash" do
@@ -339,7 +339,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting with slash using reserved characters" do
@@ -348,7 +348,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting and ending with slash" do
@@ -357,7 +357,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with path starting and ending with slash using reserved characters" do
@@ -366,7 +366,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting with slash" do
@@ -375,7 +375,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting with slash using reserved characters" do
@@ -384,7 +384,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/subfolder images/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting and ending with slash" do
@@ -393,7 +393,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/subfolder/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png"
     end
 
     test "with subfolder path starting and ending with slash using reserved characters" do
@@ -402,7 +402,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("/subfolder images/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a http url" do
@@ -411,7 +411,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("http://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a http url with reserved characters" do
@@ -420,7 +420,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("http://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a https url" do
@@ -429,7 +429,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("https://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png"
     end
 
     test "with path using a https url with reserved characters" do
@@ -438,7 +438,7 @@ defmodule ImglabTest do
         |> Source.new()
         |> Imglab.url("https://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
+      assert url == "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png"
     end
   end
 
@@ -449,7 +449,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("example.jpeg")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?signature=aRgmnJ-7b2A0QLxXpR3cqrHVYmCfpRCOglL-nsp7SdQ"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?signature=aRgmnJ-7b2A0QLxXpR3cqrHVYmCfpRCOglL-nsp7SdQ"
     end
 
     test "with params" do
@@ -458,7 +458,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     test "with params using string path" do
@@ -467,7 +467,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("example.jpeg", width: 200, height: 300, watermark: "example.svg", format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg&format=png&signature=xrwElVGVPyOrcTCNFnZiAa-tzkUp1ISrjnvEShSVsAg"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg&format=png&signature=xrwElVGVPyOrcTCNFnZiAa-tzkUp1ISrjnvEShSVsAg"
     end
 
     test "with params using string path with inline params" do
@@ -481,7 +481,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=0yhBOktmTTVC-ANSxMuGK_LakyjCOlnGTSN3I13B188"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=example.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=0yhBOktmTTVC-ANSxMuGK_LakyjCOlnGTSN3I13B188"
     end
 
     test "with params using url/3 function with source" do
@@ -497,7 +497,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Fassets%2Fexample.svg%3Fwidth%3D100%26format%3Dpng%26signature%3DiKKUBWG4kZBv6CVxwaWGPpHd9LLTfuj9CBWamNYtWaI&format=png&signature=5__R2eDq59DYQnj64dyW3VlY-earzP6uyi624Q0Q4kU"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fassets.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng%26signature%3DiKKUBWG4kZBv6CVxwaWGPpHd9LLTfuj9CBWamNYtWaI&format=png&signature=ZMT8l8i9hKs4aYiIUXpGcMSzOGHS8xjUlQeTrvE8ESA"
     end
 
     test "with params using url/3 function with source name" do
@@ -513,7 +513,7 @@ defmodule ImglabTest do
           format: "png"
         )
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Fcdn.imglab.io%2Ffixtures%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=DiMzjeskcahfac0Xsy4QNj6qoU3dvKgOuFbHT7E4usU"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&watermark=https%3A%2F%2Ffixtures.imglab-cdn.net%2Fexample.svg%3Fwidth%3D100%26format%3Dpng&format=png&signature=6BowGGEXe9wUmGa4xkhoscfPkqrLGumkIglhPQEkNuo"
     end
 
     test "with params using atoms with underscores" do
@@ -522,7 +522,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("example.jpeg", trim: "color", trim_color: "orange")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
     end
 
     test "with params using atoms with hyphens" do
@@ -531,25 +531,25 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("example.jpeg", trim: "color", "trim-color": "orange")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
     end
 
-    test "with subdomains" do
+    test "with disabled subdomains" do
       url =
         "assets"
-        |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt, subdomains: true)
+        |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt, subdomains: false)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://assets.cdn.imglab.io/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "https://imglab-cdn.net/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
-    test "with http" do
+    test "with disabled https" do
       url =
         "assets"
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt, https: false)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "http://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "http://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     test "with host" do
@@ -558,7 +558,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt, host: "imglab.net")
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://imglab.net/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "https://assets.imglab.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     test "with port" do
@@ -567,23 +567,23 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt, port: 8080)
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io:8080/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "https://assets.imglab-cdn.net:8080/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
-    test "with subdomains, http, host and port" do
+    test "with disabled subdomains, disabled https, host and port" do
       url =
         "assets"
         |> Source.new(
           secure_key: @secure_key,
           secure_salt: @secure_salt,
-          subdomains: true,
+          subdomains: false,
           https: false,
           host: "imglab.net",
           port: 8080
         )
         |> Imglab.url("example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "http://assets.imglab.net:8080/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "http://imglab.net:8080/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     test "with path starting with slash" do
@@ -592,7 +592,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     test "with path starting with slash using reserved characters" do
@@ -601,7 +601,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
+      assert url == "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
     end
 
     test "with path starting and ending with slash" do
@@ -610,7 +610,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&format=png&signature=VJ159IlBl_AlN59QWvyJov5SlQXlrZNpXgDJLJgzP8g"
     end
 
     test "with path starting and ending with slash using reserved characters" do
@@ -619,7 +619,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
+      assert url == "https://assets.imglab-cdn.net/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=yZcUhTCB9VB3qzjyIJCCX_pfJ76Gb6kHe7KwusAPl-w"
     end
 
     test "with subfolder path starting with slash" do
@@ -628,7 +628,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
+      assert url == "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
     end
 
     test "with subfolder path starting with slash using reserved characters" do
@@ -637,7 +637,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/subfolder images/example image%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
+      assert url == "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
     end
 
     test "with subfolder path starting and ending with slash" do
@@ -646,7 +646,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/subfolder/example.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
+      assert url == "https://assets.imglab-cdn.net/subfolder/example.jpeg?width=200&height=300&format=png&signature=3jydAIXhF8Nn_LXKhog2flf7FsACzISi_sXCKmASkOs"
     end
 
     test "with subfolder path starting and ending with slash using reserved characters" do
@@ -655,7 +655,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("/subfolder images/example image%2C01%2C02.jpeg/", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
+      assert url == "https://assets.imglab-cdn.net/subfolder%20images/example%20image%252C01%252C02.jpeg?width=200&height=300&format=png&signature=2oAmYelI7UEnvqSSPCfUA25TmS7na1FRVTaxfe5ADyY"
     end
 
     test "with path using a http url" do
@@ -664,7 +664,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("http://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=MuzfKbHDJY6lzeFQGRcsCS8DzxgL4nCpIowOMFLR1kA"
+      assert url == "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=MuzfKbHDJY6lzeFQGRcsCS8DzxgL4nCpIowOMFLR1kA"
     end
 
     test "with path using a http url with reserved characters" do
@@ -673,7 +673,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("http://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=78e-ysfcy3d0e0rj70QJQ3wpuwI_hAl9ZYxIUVRw62I"
+      assert url == "https://assets.imglab-cdn.net/http%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=78e-ysfcy3d0e0rj70QJQ3wpuwI_hAl9ZYxIUVRw62I"
     end
 
     test "with path using a https url" do
@@ -682,7 +682,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("https://assets.com/subfolder/example.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=7Dp8Q01u_5YmpmH-j_y4P5vzOn_9EGvh77B3fi2Ke-s"
+      assert url == "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample.jpeg?width=200&height=300&format=png&signature=7Dp8Q01u_5YmpmH-j_y4P5vzOn_9EGvh77B3fi2Ke-s"
     end
 
     test "with path using a https url with reserved characters" do
@@ -691,7 +691,7 @@ defmodule ImglabTest do
         |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
         |> Imglab.url("https://assets.com/subfolder/example%2C01%2C02.jpeg", width: 200, height: 300, format: "png")
 
-      assert url == "https://cdn.imglab.io/assets/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=-zvh2hWXP8bHkoJVh8AdJFe9Kqdd1HpP1c2UmuQcYFQ"
+      assert url == "https://assets.imglab-cdn.net/https%3A%2F%2Fassets.com%2Fsubfolder%2Fexample%252C01%252C02.jpeg?width=200&height=300&format=png&signature=-zvh2hWXP8bHkoJVh8AdJFe9Kqdd1HpP1c2UmuQcYFQ"
     end
   end
 end


### PR DESCRIPTION
* Change `Imglab.Source` default `host` attribute to `imglab-cdn.net`.
* Change `Imglab.Source` default `subdomains` attribute to `true`.
* Rename `Imglab.Source.secure?/1` function to `Imglab.Source.is_secure?/1`.