### PR TITLE
v0.2.1

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: [1.13, 1.12.3, 1.11.4, 1.10.4, 1.9.4, 1.8.2, 1.7.4, 1.6.6, 1.5.3, 1.4.5]
+        elixir: ['1.13', '1.12.3', '1.11.4', '1.10.4', '1.9.4', '1.8.2', '1.7.4', '1.6.6', '1.5.3', '1.4.5']
     container: elixir:${{ matrix.elixir }}
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -227,6 +227,28 @@ Imglab.url(
 
 `signature` query parameter will be automatically generated and attached to the nested URL value.
 
+### Specifying URLs with expiration timestamp
+
+The `expires` parameter allows you to specify a UNIX timestamp in seconds after which the request is expired.
+
+In the following example we specify an expiration time of one hour from the current time:
+
+```elixir
+expires = DateTime.utc_now() |> DateTime.add(3600) |> DateTime.to_unix()
+
+Imglab.url("assets", "image.jpeg", width: 500, expires: expires)
+```
+
+If you are using an older Elixir version without `DateTime.add/4` function you can add a number of seconds after transforming to UNIX timestamp:
+
+```elixir
+expires = DateTime.to_unix(DateTime.utc_now()) + 3600
+
+Imglab.url("assets", "image.jpeg", width: 500, expires: expires)
+```
+
+> Note: The `expires` parameter should be used in conjunction with secure sources. Otherwise, `expires` value could be tampered with.
+
 ## Generating URLs for on-premises imglab server
 
 For on-premises imglab server is possible to define custom sources pointing to your server location.

--- a/README.md
+++ b/README.md
@@ -231,10 +231,10 @@ Imglab.url(
 
 The `expires` parameter allows you to specify a UNIX timestamp in seconds after which the request is expired.
 
-In the following example we specify an expiration time of one hour from the current time:
+If an Elixir `DateTime` struct is used as value to `expires` parameter it will be automatically converted to UNIX timestamp. In the following example, we specify an expiration time of one hour, adding 3600 seconds to the current time:
 
 ```elixir
-expires = DateTime.utc_now() |> DateTime.add(3600) |> DateTime.to_unix()
+expires = DateTime.add(DateTime.utc_now(), 3600)
 
 Imglab.url("assets", "image.jpeg", width: 500, expires: expires)
 ```

--- a/lib/imglab/utils.ex
+++ b/lib/imglab/utils.ex
@@ -11,7 +11,7 @@ defmodule Imglab.Utils do
   @spec normalize_params(list) :: list
   def normalize_params(params) when is_list(params) do
     Enum.map(params, fn {key, value} ->
-      {dasherize(key), value}
+      normalize_param(dasherize(key), value)
     end)
   end
 
@@ -23,4 +23,8 @@ defmodule Imglab.Utils do
   @spec dasherize(atom | binary) :: binary
   defp dasherize(atom) when is_atom(atom), do: dasherize(Atom.to_string(atom))
   defp dasherize(string) when is_binary(string), do: String.replace(string, "_", "-")
+
+  @spec normalize_param(binary, any) :: tuple
+  defp normalize_param("expires" = key, %DateTime{} = value), do: {key, DateTime.to_unix(value)}
+  defp normalize_param(key, value), do: {key, value}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Imglab.MixProject do
   def project do
     [
       app: :imglab,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/imglab/utils_test.exs
+++ b/test/imglab/utils_test.exs
@@ -27,6 +27,9 @@ defmodule Imglab.UtilsTest do
     assert Utils.normalize_params(width: 200, height: 300) == [{"width", 200}, {"height", 300}]
     assert Utils.normalize_params(trim: "color", trim_color: "orange") == [{"trim", "color"}, {"trim-color", "orange"}]
     assert Utils.normalize_params(trim: "color", "trim-color": "orange") == [{"trim", "color"}, {"trim-color", "orange"}]
+    assert Utils.normalize_params(width: 200, expires: 1464096368) == [{"width", 200}, {"expires", 1464096368}]
+    assert Utils.normalize_params(width: 200, expires: "1464096368") == [{"width", 200}, {"expires", "1464096368"}]
+    assert Utils.normalize_params(width: 200, expires: DateTime.from_unix!(1464096368)) == [{"width", 200}, {"expires", 1464096368}]
   end
 
   test "web_uri?/1" do

--- a/test/imglab_test.exs
+++ b/test/imglab_test.exs
@@ -123,6 +123,12 @@ defmodule ImglabTest do
       assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
     end
 
+    test "with expires param using a DateTime struct" do
+      url = Imglab.url("assets", "example.jpeg", width: 200, height: 300, expires: DateTime.from_unix!(1464096368))
+
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&expires=1464096368"
+    end
+
     test "with path starting with slash" do
       url = Imglab.url("assets", "/example.jpeg", width: 200, height: 300, format: "png")
 
@@ -277,6 +283,15 @@ defmodule ImglabTest do
         |> Imglab.url("example.jpeg", trim: "color", trim_color: "orange")
 
       assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange"
+    end
+
+    test "with expires param using a DateTime struct" do
+      url =
+        "assets"
+        |> Source.new()
+        |> Imglab.url("example.jpeg", width: 200, height: 300, expires: DateTime.from_unix!(1464096368))
+
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&expires=1464096368"
     end
 
     test "with params using atoms with hyphens" do
@@ -532,6 +547,15 @@ defmodule ImglabTest do
         |> Imglab.url("example.jpeg", trim: "color", "trim-color": "orange")
 
       assert url == "https://assets.imglab-cdn.net/example.jpeg?trim=color&trim-color=orange&signature=cfYzBKvaWJhg_4ArtL5IafGYU6FEgRb_5ZADIgvviWw"
+    end
+
+    test "with expires param using a DateTime struct" do
+      url =
+        "assets"
+        |> Source.new(secure_key: @secure_key, secure_salt: @secure_salt)
+        |> Imglab.url("example.jpeg", width: 200, height: 300, expires: DateTime.from_unix!(1464096368))
+
+      assert url == "https://assets.imglab-cdn.net/example.jpeg?width=200&height=300&expires=1464096368&signature=DpkRMiecDlOaQAQM5IQ8Cd4ek8nGvfPxV6XmCN0GbAU"
     end
 
     test "with disabled subdomains" do


### PR DESCRIPTION
* Fix Elixir workflow matrix versions.
* Normalize `DateTime` structs when found as value on `expires` parameter to UNIX timestamp.
* Add README section about URLs with expiration timestamp.