### PR TITLE
Fix typos and markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ end
 And run:
 
 ```sh
-$ mix deps.get
+mix deps.get
 ```
 
 ## Elixir compatibility

--- a/lib/imglab.ex
+++ b/lib/imglab.ex
@@ -39,7 +39,7 @@ defmodule Imglab do
 
   The `signature` query string will be automatically added to the URL.
 
-  > Note: `secure_key` and `secure_salt` paramaters are secrets that should not be added to the code. Please use environment vars or other secure method to use them in your project.
+  > Note: `secure_key` and `secure_salt` parameters are secrets that should not be added to the code. Please use environment vars or other secure method to use them in your project.
 
   ## Path
 

--- a/lib/imglab/source.ex
+++ b/lib/imglab/source.ex
@@ -44,7 +44,7 @@ defmodule Imglab.Source do
     * `:secure_salt` - a `string` specifying the source secure salt
     * `:subdomains` - a `boolean` value specifying if the source should be specified using subdomains instead of using the path, only for imglab on-premises (default: `true`)
 
-  > Note: `secure_key` and `secure_salt` paramaters are secrets that should not be added to the code. Please use environment vars or other secure method to use them in your project.
+  > Note: `secure_key` and `secure_salt` parameters are secrets that should not be added to the code. Please use environment vars or other secure method to use them in your project.
 
   ## Examples
 


### PR DESCRIPTION
Remove the dollar signs used before commands without showing output.